### PR TITLE
fix: correct grammar in fr.json feedback coupon string

### DIFF
--- a/checkout/fr.json
+++ b/checkout/fr.json
@@ -95,7 +95,7 @@
                 "ratingPoor": "Faible",
                 "ratingTerrible": "Horrible",
                 "automaticFeedbackWarning": "Si vous ne laissez pas d'évaluation dans les 7 jours, une évaluation 5 étoiles sera automatiquement laissée pour vous.",
-                "feedbackCouponIncentivePercentage": "Laissez un avis {rating}★+ et bénéficiez d'{discount} % de réduction sur votre prochaine commande.",
+                "feedbackCouponIncentivePercentage": "Laissez un avis {rating}★+ et bénéficiez de {discount} % de réduction sur votre prochaine commande.",
                 "feedbackCouponIncentivePercentageNoRating": "Laissez un avis et bénéficiez d'une réduction de {discount} % sur votre prochaine commande.",
                 "feedbackCouponIncentiveFixed": "Laissez un avis « {rating}» ★+ et bénéficiez d'une réduction de {discount} sur votre prochaine commande.",
                 "feedbackCouponIncentiveFixedNoRating": "Laissez un avis et bénéficiez d'une réduction de {discount} sur votre prochaine commande.",


### PR DESCRIPTION
## Summary
- Fixes a French grammar error in the feedback coupon incentive string (`de` instead of `d'` before a number).

## Test plan
- N/A (string-only change)